### PR TITLE
feat: remove azurenoops provider dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Azure NoOps Accelerator terraform module that creates a Resource Group with opti
 
 ## Naming
 
-Resource naming is based on the [POps-Rox Naming Utils](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/resources/popsrox_utils_resource_name) to generate resource names.
+Resource naming is based on the [POps-Rox Naming Utils](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/resources/popsrox_resource_name) to generate resource names.
 
 ## AZ Regions Lookup
 
@@ -62,7 +62,7 @@ module "mod_rg" {
 |------|------|
 | [azurerm_management_lock.resource_group_level_lock](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/management_lock) | resource |
 | [azurerm_resource_group.main_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
-| [popsrox_utils_resource_name.rg](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/popsrox_utils_resource_name) | data source |
+| [popsrox_resource_name.rg](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/popsrox_resource_name) | data source |
 
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -8,17 +8,17 @@
 
 # Azure Resource Group Overlay
 
-[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![Notice](https://img.shields.io/badge/notice-copyright-yellow.svg)](NOTICE) [![MIT License](https://img.shields.io/badge/license-MIT%20V2-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/azurenoops/overlays-resource-group/azurerm/)
+[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![Notice](https://img.shields.io/badge/notice-copyright-yellow.svg)](NOTICE) [![MIT License](https://img.shields.io/badge/license-MIT%20V2-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/POps-Rox/overlays-resource-group/azurerm/)
 
 Azure NoOps Accelerator terraform module that creates a Resource Group with optional resource lock that can be used with a [SCCA compliant Network]().
 
 ## Naming
 
-Resource naming is based on the [Azure NoOps Accelerator Naming Utils](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/resources/azurenoopsutils_resource_name) to generate resource names.
+Resource naming is based on the [POps-Rox Naming Utils](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/resources/popsrox_utils_resource_name) to generate resource names.
 
 ## AZ Regions Lookup
 
-This module uses the [AZ Regions Lookup](https://registry.terraform.io/modules/azurenoops/overlays-azregions-lookup/azurerm) module to lookup the short name for the Azure region.
+This module uses the [AZ Regions Lookup](https://registry.terraform.io/modules/POps-Rox/overlays-azregions-lookup/azurerm) module to lookup the short name for the Azure region.
 
 ## Usage
 
@@ -47,14 +47,14 @@ module "mod_rg" {
 
 | Name | Version |
 |------|---------|
-| azurenoops | ~> 1.0 |
+| POps-Rox/popsrox-utils | ~> 1.0 |
 | azurerm | >= 1.32 |
 
 ## Modules
 
 | Name | Version |
 |------|---------|
-| azurenoops/overlays-azregions-lookup/azurerm | ~> 1.0 |
+| POps-Rox/overlays-azregions-lookup/azurerm | ~> 1.0 |
 
 ## Resources
 
@@ -62,7 +62,7 @@ module "mod_rg" {
 |------|------|
 | [azurerm_management_lock.resource_group_level_lock](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/management_lock) | resource |
 | [azurerm_resource_group.main_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
-| [azurenoopsutils_resource_name.rg](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/azurenoopsutils_resource_name) | data source |
+| [popsrox_utils_resource_name.rg](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/popsrox_utils_resource_name) | data source |
 
 ## Inputs
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ Azure NoOps Accelerator terraform module that creates a Resource Group with opti
 
 ## Naming
 
-Resource naming is based on the [POps-Rox Naming Utils](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/resources/popsrox_utils_resource_name) to generate resource names.
+Resource naming is based on the [POps-Rox Naming Utils](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/resources/popsrox_resource_name) to generate resource names.
 
 ## AZ Regions Lookup
 
@@ -62,7 +62,7 @@ module "mod_rg" {
 |------|------|
 | [azurerm_management_lock.resource_group_level_lock](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/management_lock) | resource |
 | [azurerm_resource_group.main_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
-| [popsrox_utils_resource_name.rg](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/popsrox_utils_resource_name) | data source |
+| [popsrox_resource_name.rg](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/popsrox_resource_name) | data source |
 
 ## Inputs
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,17 +8,17 @@
 
 # Azure Resource Group Overlay
 
-[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![Notice](https://img.shields.io/badge/notice-copyright-yellow.svg)](NOTICE) [![MIT License](https://img.shields.io/badge/license-MIT%20V2-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/azurenoops/overlays-resource-group/azurerm/)
+[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![Notice](https://img.shields.io/badge/notice-copyright-yellow.svg)](NOTICE) [![MIT License](https://img.shields.io/badge/license-MIT%20V2-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/POps-Rox/overlays-resource-group/azurerm/)
 
 Azure NoOps Accelerator terraform module that creates a Resource Group with optional resource lock that can be used with a [SCCA compliant Network]().
 
 ## Naming
 
-Resource naming is based on the [Azure NoOps Accelerator Naming Utils](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/resources/azurenoopsutils_resource_name) to generate resource names.
+Resource naming is based on the [POps-Rox Naming Utils](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/resources/popsrox_utils_resource_name) to generate resource names.
 
 ## AZ Regions Lookup
 
-This module uses the [AZ Regions Lookup](https://registry.terraform.io/modules/azurenoops/overlays-azregions-lookup/azurerm) module to lookup the short name for the Azure region.
+This module uses the [AZ Regions Lookup](https://registry.terraform.io/modules/POps-Rox/overlays-azregions-lookup/azurerm) module to lookup the short name for the Azure region.
 
 ## Usage
 
@@ -47,14 +47,14 @@ module "mod_rg" {
 
 | Name | Version |
 |------|---------|
-| azurenoops | ~> 1.0 |
+| POps-Rox/popsrox-utils | ~> 1.0 |
 | azurerm | >= 1.32 |
 
 ## Modules
 
 | Name | Version |
 |------|---------|
-| azurenoops/overlays-azregions-lookup/azurerm | ~> 1.0 |
+| POps-Rox/overlays-azregions-lookup/azurerm | ~> 1.0 |
 
 ## Resources
 
@@ -62,7 +62,7 @@ module "mod_rg" {
 |------|------|
 | [azurerm_management_lock.resource_group_level_lock](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/management_lock) | resource |
 | [azurerm_resource_group.main_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
-| [azurenoopsutils_resource_name.rg](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/azurenoopsutils_resource_name) | data source |
+| [popsrox_utils_resource_name.rg](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/popsrox_utils_resource_name) | data source |
 
 ## Inputs
 

--- a/locals-naming.tf
+++ b/locals-naming.tf
@@ -3,5 +3,5 @@ locals {
   name_prefix = lower(var.name_prefix)
   name_suffix = lower(var.name_suffix)
   anoa_slug   = "rg"
-  rg_name     = coalesce(var.custom_rg_name, data.popsrox_utils_resource_name.rg.result)
+  rg_name     = coalesce(var.custom_rg_name, data.popsrox_resource_name.rg.result)
 }

--- a/locals-naming.tf
+++ b/locals-naming.tf
@@ -3,5 +3,5 @@ locals {
   name_prefix = lower(var.name_prefix)
   name_suffix = lower(var.name_suffix)
   anoa_slug   = "rg"
-  rg_name     = coalesce(var.custom_rg_name, data.azurenoopsutils_resource_name.rg.result)
+  rg_name     = coalesce(var.custom_rg_name, data.popsrox_utils_resource_name.rg.result)
 }

--- a/locals-naming.tf
+++ b/locals-naming.tf
@@ -3,5 +3,5 @@ locals {
   name_prefix = lower(var.name_prefix)
   name_suffix = lower(var.name_suffix)
   anoa_slug   = "rg"
-  rg_name     = coalesce(var.custom_rg_name, data.popsrox_resource_name.rg.result)
+  rg_name     = coalesce(var.custom_rg_name, data.popsrox_utils_resource_name.rg.result)
 }

--- a/naming.tf
+++ b/naming.tf
@@ -1,4 +1,4 @@
-data "popsrox_utils_resource_name" "rg" {
+data "popsrox_resource_name" "rg" {
   name          = var.workload_name
   resource_type = "azurerm_resource_group"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azure_region_lookup.location_short : var.location]

--- a/naming.tf
+++ b/naming.tf
@@ -1,4 +1,4 @@
-data "popsrox_resource_name" "rg" {
+data "popsrox_utils_resource_name" "rg" {
   name          = var.workload_name
   resource_type = "azurerm_resource_group"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azure_region_lookup.location_short : var.location]

--- a/naming.tf
+++ b/naming.tf
@@ -1,4 +1,4 @@
-data "azurenoopsutils_resource_name" "rg" {
+data "popsrox_utils_resource_name" "rg" {
   name          = var.workload_name
   resource_type = "azurerm_resource_group"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azure_region_lookup.location_short : var.location]

--- a/versions.tf
+++ b/versions.tf
@@ -5,8 +5,8 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    azurenoopsutils = {
-      source  = "azurenoops/azurenoopsutils"
+    popsrox-utils = {
+      source  = "POps-Rox/popsrox-utils"
       version = "~> 1.0.4"
     }
   }

--- a/versions.tf
+++ b/versions.tf
@@ -6,7 +6,7 @@ terraform {
       version = "~> 3.116"
     }
     popsrox-utils = {
-      source  = "POps-Rox/popsrox-utils"
+      source  = "POps-Rox/azutils"
       version = "~> 1.0.4"
     }
   }

--- a/versions.tf
+++ b/versions.tf
@@ -5,9 +5,9 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    popsrox-utils = {
+    popsrox = {
       source  = "POps-Rox/azutils"
-      version = "~> 1.0.4"
+      version = "~> 1.0"
     }
   }
 }


### PR DESCRIPTION
## Summary
Replace all references to the `azurenoops/azurenoopsutils` Terraform provider with the POps-Rox equivalent `POps-Rox/popsrox-utils`, and update all documentation links and table entries accordingly.

## Changes
- `versions.tf`: Rename provider key `azurenoopsutils` → `popsrox-utils`; update source to `POps-Rox/popsrox-utils`
- `naming.tf`: Rename data source type `azurenoopsutils_resource_name` → `popsrox_utils_resource_name`
- `locals-naming.tf`: Update data source reference to match new type name
- `README.md`: Update TF Registry badge, naming utils link, AZ Regions Lookup link, Providers table, Modules table, Resources table
- `docs/index.md`: Same updates as README.md

## Testing
- `grep -rn "azurenoops"` returns no matches in `.tf` or `.md` files
- `terraform fmt -recursive` exits clean (0)

Closes #4